### PR TITLE
Fix user export with passphrase

### DIFF
--- a/lib/chef/knife/openvpn.rb
+++ b/lib/chef/knife/openvpn.rb
@@ -396,8 +396,8 @@ module OpenvpnPlugin
       config_content << 'ca ca.crt' << newline
       config_content << "cert #{user_name}.crt" << newline
       config_content << "key #{user_name}.key" << newline
-      config_content << "tls-auth ta.key 1" << newline if config['use_tls_auth']
-      config_content << "ns-cert-type server" << newline
+      config_content << 'tls-auth ta.key 1' << newline if config['use_tls_auth']
+      config_content << 'ns-cert-type server' << newline
       config_content << 'nobind' << newline
       config_content << 'persist-key' << newline
       config_content << 'persist-tun' << newline

--- a/lib/chef/knife/openvpn.rb
+++ b/lib/chef/knife/openvpn.rb
@@ -344,7 +344,7 @@ module OpenvpnPlugin
       end
 
       user_item = load_databag_item(databag_name, user_name)
-      user_cert, user_key = load_cert_and_key user_item['cert'], user_item['key']
+      user_cert, _user_key = load_cert_and_key user_item['cert'], user_item['key']
       tmpdir = Dir.mktmpdir
       ui.info "tmpdir: #{tmpdir}"
       begin
@@ -353,7 +353,7 @@ module OpenvpnPlugin
         ui.info "userdir: #{user_dir}"
         export_file "#{user_dir}/ca.crt", ca_cert.to_pem
         export_file "#{user_dir}/#{user_name}.crt", user_cert.to_pem
-        export_file "#{user_dir}/#{user_name}.key", user_key.to_pem
+        export_file "#{user_dir}/#{user_name}.key", user_item['key'].to_s
         export_file "#{user_dir}/ta.key", ta_key unless ta_key.empty?
         config_content = generate_client_config server_name, user_name
         export_file "#{user_dir}/#{user_name}.ovpn", config_content


### PR DESCRIPTION
When exporting a key w/ a passphrase, the passphrase should not be removed.  This still requires the key to be decrypted but not the decrypted version not used on export for security purposes.
